### PR TITLE
SEC-2678 fix catalog-info.yaml validation errors

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,10 +6,6 @@ metadata:
   tags: ['code-lang:actions']
   description: Public repository with Github Actions
   links:
-    - title: Linear
-      url: PLACEHOLDER-ADD-LINEAR-URL
-    - title: Documentation
-      url: PLACEHOLDER-ADD-DOCUMENTATION-URL
     - title: Slack
       url: https://tfh.slack.com/app_redirect?channel=team-infrastructure
   name: gh-actions-public


### PR DESCRIPTION
## Summary

Automated cleanup of `catalog-info.yaml` so the entity passes Backstage catalog validation. The same defects were repeated on every catalog refresh and dominated the `service:backstage` log volume (the "Policy check failed" family was 69% of all logs).

This change does one or more of:
- Removes never-filled placeholder links (`PLACEHOLDER-ADD-*-URL`, `N/A`) that are not valid URLs. Real links are kept.
- Normalizes `code-lang:` tags to lowercase with dashes (e.g. `code-lang:TypeScript` to `code-lang:typescript`). Colons are preserved.
- Drops empty or placeholder tags.

No functional or ownership changes. Part of the Backstage logging cleanup tracked in [SEC-2678](https://linear.app/worldcoin/issue/SEC-2678).

## Test plan

Backstage re-validates the entity on its next refresh; the repeating `Policy check failed for component:default/<name>` warning for this repo should stop.
